### PR TITLE
Revert option to store closure rather than concrete instances and 1.0 preparations

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,16 @@
+#  Licenses
+
+## Personal and non-commercial
+
+Everyone may use and modify freely for their own non-commercial software, personal experimentation and learning.
+
+## Commercial licensing and distribution licensing
+
+The following individuals and organisations are granted a non-expiring license to use, modify and distribute this software with their products and use in their internal developments. If you or organisation would like to be licensed make a PR to modify this file to add the propsed additional licensee. The PR is likely to be accepted (and rapidly) in almost all cases and there is no financial cost. The contribution of the PR and recognition will in most cases be accepted as consideration.
+
+Human Friendly Ltd.
+Pulselive Innovations Ltd.
+
+If you would like alternative license conditions you can make the proposal in the PR and explain in the description or make contact to directly by email. joseph @ human-friendly.com.
+
+If you wish to use in a signficant existing open source project and need the license to be compatible I would definitely consider adopting a relevant license. Again please get in touch.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently there is a small test suite covering all the happy cases. There is ano
 
 It may well be that rather than have it as an external dependency you instead just drop the file into your project as a single file library (might build quicker that way than pulling the package from git).
 
-See the [License.md](license.md) file for information on licensing.
+See the [LICENSE.md](LICENSE.md) file for information on licensing.
 
 ## Help wanted
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroInjection
 
-A tiny (~100 lines including comments and whitespace) dependency injection framework taking the same approach as the SwiftUI environment.
+A tiny (40 lines or ~100 lines including comments and whitespace) dependency injection framework inspired by the SwiftUI environment.
 
 Read the [blog post about it](https://blog.human-friendly.com/how-does-the-swiftui-environment-work-and-can-it-be-used-outside-swiftui-for-dependency-injection).
 
@@ -14,10 +14,8 @@ Currently there is a small test suite covering all the happy cases. There is ano
 
 It may well be that rather than have it as an external dependency you instead just drop the file into your project as a single file library (might build quicker that way than pulling the package from git).
 
-Regarding license I haven't decided yet, let me know if you are planning to use it. Unless I regard your purpose or organisation as evil I'll grant you a very broad license if you want. Feel free to experment before requesting the license to distribute the code.
+See the [License.md](license.md) file for information on licensing.
 
 ## Help wanted
-
-API naming improvement suggestions. I would like other eyes on it if possible before stabilising it for a 1.0 release before March 2021.
 
 If you can see a way to allow the property wrapper to be used on structs and enums that is the additional feature that I'm looking for.

--- a/Tests/MicroInjectionTests/MicroInjectionTests.swift
+++ b/Tests/MicroInjectionTests/MicroInjectionTests.swift
@@ -152,26 +152,29 @@ final class MicroInjectionTests: XCTestCase {
     }
 
 
-    func testExtendInjectionSetValueClosure() {
-        var injection = InjectionValues()
-        injection.set(key: AKey.self) { "A" }
-        XCTAssertEqual(injection.a, "A")
-        XCTAssertEqual(injection[AKey.self], "A")
-    }
-
-    func testPropertyWrapperComputed() {
-        class Bar : Injectable {
-            init(injection: InjectionValues) {
-                self.injection = injection
-            }
-            let injection: InjectionValues
-            @Injection(\.a) var a
-        }
-        var injection = InjectionValues()
-        injection.set(key: AKey.self) { "A" }
-        let bar = Bar(injection: injection)
-        XCTAssertEqual(bar.a, "A")
-    }
+// The functionality to set an overriding closure has been removed. It could potentially
+// be readded in the future but I think it is an unnecessary level of complication.
+// Just because something can be done doesn't mean it should be done.
+//    func testExtendInjectionSetValueClosure() {
+//        var injection = InjectionValues()
+//        injection.set(key: AKey.self) { "A" }
+//        XCTAssertEqual(injection.a, "A")
+//        XCTAssertEqual(injection[AKey.self], "A")
+//    }
+//
+//    func testPropertyWrapperComputed() {
+//        class Bar : Injectable {
+//            init(injection: InjectionValues) {
+//                self.injection = injection
+//            }
+//            let injection: InjectionValues
+//            @Injection(\.a) var a
+//        }
+//        var injection = InjectionValues()
+//        injection.set(key: AKey.self) { "A" }
+//        let bar = Bar(injection: injection)
+//        XCTAssertEqual(bar.a, "A")
+//    }
     
 // I would like to be able to make this work but don't currently know a
 // mechanism to support structs being Injectable. This is a nice to have if
@@ -196,7 +199,5 @@ final class MicroInjectionTests: XCTestCase {
         ("testCallForUnstoredNil", testCallForUnstoredNil),
         ("testCallForUnstoredReturn", testCallForUnstoredReturn),
         ("testCallForUnstoredNoCallWhenStored", testCallForUnstoredNoCallWhenStored),
-        ("testExtendInjectionSetValueClosure", testExtendInjectionSetValueClosure),
-        ("testPropertyWrapperComputed", testPropertyWrapperComputed),
     ]
 }


### PR DESCRIPTION
Revert change to storing concrete values rather than allowing overriding closures.

Addition of LICENSE.md file.

Updates to README.